### PR TITLE
Update test-and-release.yml to use node 16/18/20 and newest test support

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -3,68 +3,90 @@ name: Test and Release
 # Run this job on all pushes and pull requests
 # as well as tags with a semantic version
 on:
-  push:
-    branches:
-      - "*"
-    tags:
-      # normal versions
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      # pre-releases
-      - "v[0-9]+.[0-9]+.[0-9]+-**"
-  pull_request: {}
+    push:
+        branches:
+            - '*'
+        tags:
+            # normal versions
+            - 'v[0-9]+.[0-9]+.[0-9]+'
+            # pre-releases
+            - 'v[0-9]+.[0-9]+.[0-9]+-**'
+    pull_request: {}
+
+# Cancel previous PR/branch runs when a new commit is pushed
+concurrency:
+    group: ${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  # Performs quick checks before the expensive test runs
-  check-and-lint:
-    if: contains(github.event.head_commit.message, '[skip ci]') == false
+    # Performs quick checks before the expensive test runs
+    check-and-lint:
+        if: contains(github.event.head_commit.message, '[skip ci]') == false
 
-    runs-on: ubuntu-latest
+        runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
+        steps:
+            - uses: ioBroker/testing-action-check@v1
+              with:
+                  node-version: '18.x'
+                  # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+                  # install-command: 'npm install'
+                  lint: true
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+    # Runs adapter tests on all supported node versions and OSes
+    adapter-tests:
+        if: contains(github.event.head_commit.message, '[skip ci]') == false
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                node-version: [16.x, 18.x, 20.x]
+                os: [ubuntu-latest, windows-latest, macos-latest]
 
-      - name: Install Dependencies
-        run: npm ci
+        steps:
+            - uses: ioBroker/testing-action-adapter@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  os: ${{ matrix.os }}
+                  # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+                  # install-command: 'npm install'
 
-      - name: Lint source code
-        run: npm run lint
-      - name: Test package files
-        run: npm run test:package
+    # TODO: To enable automatic npm releases, create a token on npmjs.org
+    # Enter this token as a GitHub secret (with name NPM_TOKEN) in the repository options
+    # Then uncomment the following block:
 
-  # Runs adapter tests on all supported node versions and OSes
-  adapter-tests:
-    if: contains(github.event.head_commit.message, '[skip ci]') == false
-
-    needs: [check-and-lint]
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node-version: [16.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Run unit tests
-        run: npm run test:unit
-
+#    # Deploys the final package to NPM
+#    deploy:
+#        needs: [check-and-lint, adapter-tests]
+#
+#        # Trigger this step only when a commit on any branch is tagged with a version number
+#        if: |
+#            contains(github.event.head_commit.message, '[skip ci]') == false &&
+#            github.event_name == 'push' &&
+#            startsWith(github.ref, 'refs/tags/v')
+#
+#        runs-on: ubuntu-latest
+#
+#        # Write permissions are required to create Github releases
+#        permissions:
+#            contents: write
+#
+#        steps:
+#            - uses: ioBroker/testing-action-deploy@v1
+#              with:
+#                  node-version: '18.x'
+#                  # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+#                  # install-command: 'npm install'
+#                  npm-token: ${{ secrets.NPM_TOKEN }}
+#                  github-token: ${{ secrets.GITHUB_TOKEN }}
+#
+#                  # When using Sentry for error reporting, Sentry can be informed about new releases
+#                  # To enable create a API-Token in Sentry (User settings, API keys)
+#                  # Enter this token as a GitHub secret (with name SENTRY_AUTH_TOKEN) in the repository options
+#                  # Then uncomment and customize the following block:
+##          sentry: true
+##          sentry-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+##          sentry-project: "iobroker-pid"
+##          sentry-version-prefix: "iobroker.pid"
+##          # If your sentry project is linked to a GitHub repository, you can enable the following option
+##          # sentry-github-integration: true


### PR DESCRIPTION
This PR updates test-and-release workflow to 

- use node 16 / 18 / 20 for testing 
- update workflow to use current iobroker standard testing


Please merge for next release.

Please also note that you can unumment the last section of test-and-release workflow to get an automatic deploy to npm if desired. This is fully optional and only your decision.
